### PR TITLE
Renamed the link for checkout/khalti-epayment to khalti-epayment

### DIFF
--- a/content/checkout/web.md
+++ b/content/checkout/web.md
@@ -3,7 +3,7 @@
 <div class='deprecated'>
 This version of Web SDK has been deprecated and replaced by e-Payment (checkout) version.
 <br />
-Please refer to <a href="/checkout/khalti-epayment/">checkout/khalti-epayment</a> for the latest version
+Please refer to <a href="/khalti-epayment/">khalti-epayment</a> for the latest version
 </div>
 
 [![npm](https://img.shields.io/badge/npm-v2.2.0-blue.svg)](https://www.npmjs.com/package/khalti-checkout-web)


### PR DESCRIPTION
The link in the current live documentation is broken. The following update to the link fixes the issue.